### PR TITLE
Removed an unused import and fixed the NFT Image link and NFT Author …

### DIFF
--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -1,6 +1,5 @@
 import axios from "axios";
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import { HotCollectionsCarousel, HotCollectionsCarouselSkeleton } from "./components/HotCollectionsCarousel";
 
 const HotCollections = () => {

--- a/src/components/home/components/HotCollectionsCarousel.jsx
+++ b/src/components/home/components/HotCollectionsCarousel.jsx
@@ -58,7 +58,7 @@ export const HotCollectionsCarousel = ({ collections }) => {
             >
               <div className="nft_coll">
                 <div className="nft_wrap">
-                  <Link to="/item-details">
+                  <Link to={`/item-details/${collection.nftId}`}>
                     <img
                       src={collection.nftImage}
                       className="lazy img-fluid"
@@ -67,7 +67,7 @@ export const HotCollectionsCarousel = ({ collections }) => {
                   </Link>
                 </div>
                 <div className="nft_coll_pp">
-                  <Link to="/author">
+                  <Link to={`/author/${collection.authorId}`}>
                     <img
                       className="lazy pp-coll"
                       src={collection.authorImage}


### PR DESCRIPTION
Task:

1. Removed the unused "Link" import in the HotCollections.jsx file
2. Edited the Links of the NFT Image and Author of the Hot Collections

How:

1. Just deleted the line.
3. Added /${collection.nftId} and /${collection.authorId} to the Links in the HotCollectionsCarousel when it maps the whole NFT collection.